### PR TITLE
Add 'latest*' tag trigger to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,8 +3,8 @@ name: Build Release Binaries
 on:
   push:
     tags:
-      - 'v*' # Se lance quand vous créez un tag type "v1.0"
-
+      - 'v*'
+      - 'latest*'
 jobs:
   build:
     name: Build on ${{ matrix.os }}


### PR DESCRIPTION
Include the 'latest*' tag pattern under push.tags so the release workflow runs for tags that start with "latest". Also removed an inline French comment and minor whitespace changes.